### PR TITLE
chore: Remove unnecessary backslash

### DIFF
--- a/spec/standard-webhooks.md
+++ b/spec/standard-webhooks.md
@@ -219,7 +219,7 @@ To achieve this, the webhook is signed both using the current key, and using an 
 Example headers:
 
 ```
-webhook-id: msg_2KWPBgLlAfxdpx2AI54pPJ85f4W\
+webhook-id: msg_2KWPBgLlAfxdpx2AI54pPJ85f4W
 webhook-timestamp: 1674087231
 webhook-signature: v1,K5oZfzN95Z9UVu1EsfQmfVNQhnkZ2pj9o9NDN/H/pI4= v1a,hnO3f9T8Ytu9HwrXslvumlUpqtNVqkhqw/enGzPCXe5BdqzCInXqYXFymVJaA7AZdpXwVLPo3mNl8EM+m7TBAg==
 ```


### PR DESCRIPTION
This is a tiny change that removes a backslash (`\`) from the specification example of headers.

I don't think this is necessary because after it is a single newline in a code block; also, the next line doesn't have it either. But please correct me if I'm wrong!