### PR TITLE
PHP: minor cleanup

### DIFF
--- a/libraries/php/README.md
+++ b/libraries/php/README.md
@@ -25,9 +25,9 @@ If you use Composer, these dependencies should be handled automatically. If you 
 
  - PHP >= 5.6.0
 
-## Building the library
+## Installing dependencies
 ```sh
-dotnet build
+composer install
 ```
 
 ## Contributing

--- a/libraries/php/src/Webhook.php
+++ b/libraries/php/src/Webhook.php
@@ -62,6 +62,7 @@ class Webhook
 
     public function sign($msgId, $timestamp, $payload)
     {
+        $timestamp = (string) $timestamp;
         $is_positive_integer = ctype_digit($timestamp);
         if (!$is_positive_integer) {
             throw new Exception\WebhookSigningException("Invalid timestamp");

--- a/libraries/php/tests/WebhookTest.php
+++ b/libraries/php/tests/WebhookTest.php
@@ -112,6 +112,8 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
     public function testMultiSigPayloadIsValid()
     {
+        $this->expectNotToPerformAssertions();
+
         $testPayload = new TestPayload(time());
         $sigs = [
             "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
@@ -127,6 +129,8 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
     public function testSignatureVerificationWithAndWithoutPrefix()
     {
+        $this->expectNotToPerformAssertions();
+
         $testPayload = new TestPayload(time());
 
         $wh = new \StandardWebhooks\Webhook($testPayload->secret);


### PR DESCRIPTION
This PR includes the following changes:
- Clean up an error in the README
- Mark a couple of tests as without assertions to prevent these tests from being marked as risky (they're not)
- Minor php8 compatibility fix: cast the timestamp to a string in \StandardWebhooks\Webhook::sign() to prevent a deprecation notice
