### PR TITLE
chore(ci): prefer `working-directory` instead of `cd`

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -1,9 +1,10 @@
-name: Csharp Lint
+name: C# Lint
 
 on:
   pull_request:
     paths:
       - "libraries/csharp/**"
+      - ".github/workflows/csharp-lint.yml"
 
 jobs:
   dotnet:

--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd libraries/csharp
           dotnet restore
+        working-directory: libraries/csharp
 
       - name: Build
         run: |
-          cd libraries/csharp
           dotnet build --configuration Release StandardWebhooks --no-restore
+        working-directory: libraries/csharp

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -3,7 +3,7 @@ name: C# Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   dotnet:
@@ -20,19 +20,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd libraries/csharp
           dotnet restore
+        working-directory: libraries/csharp
 
       - name: Build
         run: |
-          cd libraries/csharp
-          dotnet build --configuration Release StandardWebhooks --no-restore
+          otnet build --configuration Release StandardWebhooks --no-restore
+        working-directory: libraries/csharp
 
       - name: Release
         run: |
-          cd libraries/csharp
           dotnet nuget push "$(find StandardWebhooks/bin/Release/StandardWebhooks.*.nupkg)" \
             --api-key "$NUGET_API_KEY" \
             --source "https://api.nuget.org/v3/index.json"
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        working-directory: libraries/csharp

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          otnet build --configuration Release StandardWebhooks --no-restore
+          dotnet build --configuration Release StandardWebhooks --no-restore
         working-directory: libraries/csharp
 
       - name: Release

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -20,4 +20,5 @@ jobs:
           working-directory: libraries/go
           args: "--out-format colored-line-number"
       - name: run tests
-        run: cd libraries && go test -v ./...
+        run: go test -v ./...
+        working-directory: libraries

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,12 +1,17 @@
 name: Go Lint
+
 on:
   pull_request:
     paths:
       - "libraries/go/**"
+      - "libraries/go.mod"
       - ".github/workflows/go-lint.yml"
+
 jobs:
   build:
+    name: Go Lint
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup go

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -1,10 +1,13 @@
 name: Java Lint
+
 on:
   pull_request:
     paths:
       - "libraries/java/**"
+      - ".github/workflows/java-lint.yml"
+
 jobs:
-  dotnet:
+  build:
     name: Java Lint
     runs-on: ubuntu-latest
 

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-  
+
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
-          java-version: '11'
-  
+          distribution: "temurin"
+          java-version: "11"
+
       - name: Build
         run: |
-          cd libraries/java
           ./gradlew build
+        working-directory: libraries/java

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -3,7 +3,7 @@ name: Java Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   dotnet:
@@ -16,8 +16,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
 
       - name: Restore gradle.properties
         run: |
@@ -41,8 +41,8 @@ jobs:
           echo -e "$OSSRH_GPG_SECRET_KEY" | gpg --batch --import
         env:
           OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-  
+
       - name: Publish
         run: |
-          cd libraries/java
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        working-directory: libraries/java

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  dotnet:
+  build:
     name: Java Release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -11,10 +11,10 @@ jobs:
 
       - name: Install modules
         run: |
-          cd libraries/javascript
           yarn
+        working-directory: libraries/javascript
 
       - name: Lint
         run: |
-          cd libraries/javascript
           yarn run lint
+        working-directory: libraries/javascript

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -1,11 +1,16 @@
-name: Javascript Lint
+name: JavaScript Lint
+
 on:
   pull_request:
     paths:
       - "libraries/javascript/**"
+      - ".github/workflows/javascript-lint.yml"
+
 jobs:
   build:
+    name: JavaScript Lint
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -1,4 +1,4 @@
-name: Javascript Release
+name: JavaScript Release
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
+    name: JavaScript Release
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -3,7 +3,7 @@ name: Javascript Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   build:
@@ -13,17 +13,17 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install modules
         run: |
-          cd libraries/javascript
           yarn
+        working-directory: libraries/javascript
 
       - name: Publish
         run: |
-          cd libraries/javascript
           yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: libraries/javascript

--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -3,7 +3,7 @@ name: PHP Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   packagist:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,11 +1,16 @@
 name: Python Lint
+
 on:
   pull_request:
     paths:
       - "libraries/python/**"
+      - ".github/workflows/python-lint.yml"
+
 jobs:
   build:
+    name: Python Lint
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,5 @@
 name: Python Lint
-on: 
+on:
   pull_request:
     paths:
       - "libraries/python/**"
@@ -12,21 +12,21 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install deps
         run: |
-          cd libraries/python
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt .
           python -m pip install -r requirements-dev.txt .
+        working-directory: libraries/python
 
       - name: Run linting
         run: |
-          cd libraries/python
           sh ./scripts/lint.sh
+        working-directory: libraries/python
 
       - name: Run test
-        run: | 
-          cd libraries/python
+        run: |
           pytest
+        working-directory: libraries/python

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -3,7 +3,7 @@ name: Python Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   build:
@@ -15,24 +15,24 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install deps
         run: |
-          cd libraries/python
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt .
           python -m pip install -r requirements-dev.txt .
+        working-directory: libraries/python
 
       - name: Install setuptools
         run: |
-          cd libraries/python
           python -m pip install setuptools
+        working-directory: libraries/python
 
       - name: Build sdist
         run: |
-          cd libraries/python
           python setup.py sdist
+        working-directory: libraries/python
 
       - uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     paths:
       - "libraries/ruby/**"
+      - ".github/workflows/ruby-lint.yml"
 
 jobs:
-  dotnet:
+  build:
     name: Ruby Lint
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -1,6 +1,6 @@
 name: Ruby Lint
 
-on: 
+on:
   pull_request:
     paths:
       - "libraries/ruby/**"
@@ -20,10 +20,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd libraries/ruby
           bundler install
+        working-directory: libraries/ruby
 
       - name: Build
         run: |
-          cd libraries/ruby
           bundler exec rake build
+        working-directory: libraries/ruby

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  dotnet:
+  build:
     name: Ruby Release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -3,7 +3,7 @@ name: Ruby Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   dotnet:
@@ -20,13 +20,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd libraries/ruby
           bundler install
+        working-directory: libraries/ruby
 
       - name: Build
         run: |
-          cd libraries/ruby
           bundler exec rake build
+        working-directory: libraries/ruby
 
       - name: Publish
         run: |
@@ -35,7 +35,7 @@ jobs:
           chmod 0600 "$HOME/.gem/credentials"
           printf -- "---\n:rubygems_api_key: %s\n" "$RUBYGEMS_AUTH_TOKEN" > "$HOME/.gem/credentials"
 
-          cd libraries/ruby
           gem push pkg/*.gem
         env:
           RUBYGEMS_AUTH_TOKEN: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        working-directory: libraries/ruby

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
-      - 'libraries/rust/**'
-      - '.github/workflows/rust-lint.yml'
+      - "libraries/rust/**"
+      - ".github/workflows/rust-lint.yml"
   pull_request:
     paths:
-      - 'libraries/rust/**'
-      - '.github/workflows/rust-lint.yml'
+      - "libraries/rust/**"
+      - ".github/workflows/rust-lint.yml"
 
 jobs:
   test-versions:
@@ -20,33 +20,33 @@ jobs:
       matrix:
         rust: [stable, beta]
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
-        profile: minimal
-        components: clippy, rustfmt
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
+          components: clippy, rustfmt
 
-    - uses: Swatinem/rust-cache@v1
-      with:
-        working-directory: libraries/rust
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: libraries/rust
 
-    - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path libraries/rust/Cargo.toml --all --all-targets --all-features -- -D warnings
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path libraries/rust/Cargo.toml --all --all-targets --all-features -- -D warnings
 
-    - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --manifest-path libraries/rust/Cargo.toml --all -- --check
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path libraries/rust/Cargo.toml --all -- --check
 
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path libraries/rust/Cargo.toml --all
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path libraries/rust/Cargo.toml --all

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -3,7 +3,7 @@ name: Rust Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   build:
@@ -13,11 +13,11 @@ jobs:
 
       - name: Hack around cargo stuff
         run: |
-          cd libraries/rust/
           git config user.email "work@around.com"
           git config user.name "Work Around"
           git add -f src/apis/ src/models/
           git commit -a -m "Snap"
+        working-directory: libraries/rust
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -3,22 +3,22 @@ name: Rust Lib Security
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-      - 'libraries/rust/**/Cargo.toml'
-      - 'libraries/rust/**/Cargo.lock'
-      - '.github/workflows/rust-security.yml'
+      - "libraries/rust/**/Cargo.toml"
+      - "libraries/rust/**/Cargo.lock"
+      - ".github/workflows/rust-security.yml"
   pull_request:
     paths:
-      - 'libraries/rust/**/Cargo.toml'
-      - 'libraries/rust/**/Cargo.lock'
-      - '.github/workflows/rust-security.yml'
+      - "libraries/rust/**/Cargo.toml"
+      - "libraries/rust/**/Cargo.lock"
+      - ".github/workflows/rust-security.yml"
 
 jobs:
-  security_audit:
+  security-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-            arguments: --manifest-path=libraries/rust/Cargo.toml
+          arguments: --manifest-path=libraries/rust/Cargo.toml


### PR DESCRIPTION
This PR includes the following changes:

- Features
  - Use `working-directory` instead of `cd` in GitHub Workflows ([docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsworking-directory))
  - Update to include GitHub Workflow files in `paths` itself to trigger the lint
  - Add missing `go.mod` path to `.github/workflows/go-lint.yml`
- Display
  - Add missing `name` attribute for GitHub Workflow jobs
  - Update pipeline name (`Csharp Lint` -> `C# Lint`)
  - Update pipeline name (`Javascript` -> `JavaScript`)
- Some formattings (empty space, quote, etc)