### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @standard-webhooks/technical-steering-committee


### PR DESCRIPTION
Adding codeowners to require reviews from the TSC.

@tasn we need to make the team public to be able to add the codeowners feature.