### PR TITLE
Go library errors improvements

### DIFF
--- a/libraries/go/webhook.go
+++ b/libraries/go/webhook.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -28,11 +29,11 @@ const webhookSecretPrefix = "whsec_"
 var tolerance time.Duration = 5 * time.Minute
 
 var (
-	errRequiredHeaders     = fmt.Errorf("missing required headers")
-	errInvalidHeaders      = fmt.Errorf("invalid signature headers")
-	errNoMatchingSignature = fmt.Errorf("no matching signature found")
-	errMessageTooOld       = fmt.Errorf("message timestamp too old")
-	errMessageTooNew       = fmt.Errorf("message timestamp too new")
+	errRequiredHeaders     = errors.New("missing required headers")
+	errInvalidHeaders      = errors.New("invalid signature headers")
+	errNoMatchingSignature = errors.New("no matching signature found")
+	errMessageTooOld       = errors.New("message timestamp too old")
+	errMessageTooNew       = errors.New("message timestamp too new")
 )
 
 func NewWebhook(secret string) (*Webhook, error) {

--- a/libraries/go/webhook.go
+++ b/libraries/go/webhook.go
@@ -25,11 +25,11 @@ var base64enc = base64.StdEncoding
 var tolerance time.Duration = 5 * time.Minute
 
 var (
-	errRequiredHeaders     = errors.New("missing required headers")
-	errInvalidHeaders      = errors.New("invalid signature headers")
-	errNoMatchingSignature = errors.New("no matching signature found")
-	errMessageTooOld       = errors.New("message timestamp too old")
-	errMessageTooNew       = errors.New("message timestamp too new")
+	ErrRequiredHeaders     = errors.New("missing required headers")
+	ErrInvalidHeaders      = errors.New("invalid signature headers")
+	ErrNoMatchingSignature = errors.New("no matching signature found")
+	ErrMessageTooOld       = errors.New("message timestamp too old")
+	ErrMessageTooNew       = errors.New("message timestamp too new")
 )
 
 type Webhook struct {
@@ -78,7 +78,7 @@ func (wh *Webhook) verify(payload []byte, headers http.Header, enforceTolerance 
 	msgSignature := headers.Get(HeaderWebhookSignature)
 	msgTimestamp := headers.Get(HeaderWebhookTimestamp)
 	if msgId == "" || msgSignature == "" || msgTimestamp == "" {
-		return errRequiredHeaders
+		return ErrRequiredHeaders
 	}
 
 	timestamp, err := parseTimestampHeader(msgTimestamp)
@@ -115,7 +115,7 @@ func (wh *Webhook) verify(payload []byte, headers http.Header, enforceTolerance 
 			return nil
 		}
 	}
-	return errNoMatchingSignature
+	return ErrNoMatchingSignature
 }
 
 func (wh *Webhook) Sign(msgId string, timestamp time.Time, payload []byte) (string, error) {
@@ -132,7 +132,7 @@ func (wh *Webhook) Sign(msgId string, timestamp time.Time, payload []byte) (stri
 func parseTimestampHeader(timestampHeader string) (time.Time, error) {
 	timeInt, err := strconv.ParseInt(timestampHeader, 10, 64)
 	if err != nil {
-		return time.Time{}, errInvalidHeaders
+		return time.Time{}, ErrInvalidHeaders
 	}
 	timestamp := time.Unix(timeInt, 0)
 	return timestamp, nil
@@ -142,10 +142,10 @@ func verifyTimestamp(timestamp time.Time) error {
 	now := time.Now()
 
 	if now.Sub(timestamp) > tolerance {
-		return errMessageTooOld
+		return ErrMessageTooOld
 	}
 	if timestamp.Unix() > now.Add(tolerance).Unix() {
-		return errMessageTooNew
+		return ErrMessageTooNew
 	}
 
 	return nil

--- a/libraries/go/webhook.go
+++ b/libraries/go/webhook.go
@@ -16,15 +16,11 @@ const (
 	HeaderWebhookID        string = "webhook-id"
 	HeaderWebhookSignature string = "webhook-signature"
 	HeaderWebhookTimestamp string = "webhook-timestamp"
+
+	webhookSecretPrefix string = "whsec_"
 )
 
 var base64enc = base64.StdEncoding
-
-type Webhook struct {
-	key []byte
-}
-
-const webhookSecretPrefix = "whsec_"
 
 var tolerance time.Duration = 5 * time.Minute
 
@@ -35,6 +31,10 @@ var (
 	errMessageTooOld       = errors.New("message timestamp too old")
 	errMessageTooNew       = errors.New("message timestamp too new")
 )
+
+type Webhook struct {
+	key []byte
+}
 
 func NewWebhook(secret string) (*Webhook, error) {
 	key, err := base64enc.DecodeString(strings.TrimPrefix(secret, webhookSecretPrefix))

--- a/libraries/go/webhook.go
+++ b/libraries/go/webhook.go
@@ -28,11 +28,11 @@ const webhookSecretPrefix = "whsec_"
 var tolerance time.Duration = 5 * time.Minute
 
 var (
-	errRequiredHeaders     = fmt.Errorf("Missing Required Headers")
-	errInvalidHeaders      = fmt.Errorf("Invalid Signature Headers")
-	errNoMatchingSignature = fmt.Errorf("No matching signature found")
-	errMessageTooOld       = fmt.Errorf("Message timestamp too old")
-	errMessageTooNew       = fmt.Errorf("Message timestamp too new")
+	errRequiredHeaders     = fmt.Errorf("missing required headers")
+	errInvalidHeaders      = fmt.Errorf("invalid signature headers")
+	errNoMatchingSignature = fmt.Errorf("no matching signature found")
+	errMessageTooOld       = fmt.Errorf("message timestamp too old")
+	errMessageTooNew       = fmt.Errorf("message timestamp too new")
 )
 
 func NewWebhook(secret string) (*Webhook, error) {


### PR DESCRIPTION
Hi!

A few improvements on the Go library side :
* Don't capitalize error strings ([ST1005](https://staticcheck.dev/docs/checks/#ST1005)).
* Use `errors.New` instead of `fmt.Errorf` when creating "known" errors, as it's not formatting anything.
* Expose these errors (I think that it would be a good idea, making them usable by clients of the library, up for debate of course).
* Wrap most errors to add some context for callers (up for debate as well, please let me know what you think).

Thanks :)