### PR TITLE
feat(ci): Update outdated github action versions

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
 

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 5.0.x
 

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -13,17 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: libraries/go.mod
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           working-directory: libraries/go
           args: "--out-format colored-line-number"
+
       - name: run tests
         run: go test -v ./...
         working-directory: libraries

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "11"

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "11"
@@ -31,10 +31,10 @@ jobs:
             echo "signing.gnupg.passphrase=$OSSRH_GPG_SECRET_KEY_PASSWORD"
           } >> ~/.gradle/gradle.properties
         env:
-          NEXUS_USERNAME: "${{secrets.NEXUS_USERNAME}}"
-          NEXUS_PASSWORD: "${{secrets.NEXUS_PASSWORD}}"
-          OSSRH_GPG_KEY_NAME: "${{secrets.OSSRH_GPG_KEY_NAME}}"
-          OSSRH_GPG_SECRET_KEY_PASSWORD: "${{secrets.OSSRH_GPG_SECRET_KEY_PASSWORD}}"
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          OSSRH_GPG_KEY_NAME: ${{ secrets.OSSRH_GPG_KEY_NAME }}
+          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
 
       - name: Install GPG Signing Key
         run: |

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install modules
         run: |

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,5 +1,6 @@
-name: Php Lint
-on: 
+name: PHP Lint
+
+on:
   pull_request:
     paths:
       - "libraries/php/**"
@@ -8,16 +9,21 @@ on:
       - ".github/workflows/php-lint.yml"
 jobs:
   build:
+    name: PHP Lint
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
-      - uses: php-actions/composer@v6
-        name: Install dependencies
+
+      - name: Install dependencies
+        uses: php-actions/composer@v6
         with:
           working_dir: "libraries"
+
       - name: run lint
         working-directory: libraries
         run: vendor/bin/php-cs-fixer fix -v --dry-run --diff .
+
       - name: run tests
-        working-directory: libraries
         run: vendor/bin/phpunit php/tests
+        working-directory: libraries

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
-        name: Install Python
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: "3.11"
@@ -34,7 +34,7 @@ jobs:
           python setup.py sdist
         working-directory: libraries/python
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: "2.7"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: "2.7"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -20,33 +20,25 @@ jobs:
       matrix:
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: libraries/rust
+          workspaces: libraries/rust -> target
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path libraries/rust/Cargo.toml --all --all-targets --all-features -- -D warnings
+        run: cargo clippy --all --all-targets --all-features -- -D warnings
+        working-directory: libraries/rust
 
       - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path libraries/rust/Cargo.toml --all -- --check
+        run: cargo fmt --all -- --check
+        working-directory: libraries/rust
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path libraries/rust/Cargo.toml --all
+        run: cargo test --all
+        working-directory: libraries/rust

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Hack around cargo stuff
         run: |
@@ -19,19 +19,17 @@ jobs:
           git commit -a -m "Snap"
         working-directory: libraries/rust
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
-          profile: minimal
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: libraries/rust -> target
 
       - name: Publish
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --manifest-path libraries/rust/Cargo.toml
+        working-directory: libraries/rust

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -17,8 +17,10 @@ on:
 jobs:
   security-audit:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           arguments: --manifest-path=libraries/rust/Cargo.toml


### PR DESCRIPTION
This PR includes the following changes:

- actions version update
  - `actions/checkout`: `v2`, `v3`, `master` → `v4` ([changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md))
  - `actions/setup-dotnet`: `v1.7.2` → `v4`
  - `actions/setup-go`: `v4` → `v5`
  - `actions/setup-java`: `v2` → `v4`
  - `actions/setup-node`: `v2` → `v4`
  - `actions/setup-python`: `v2` → `v5`
  - `pypa/gh-action-pypi-publish`: `master` → `release/v1`
  - `Swatinem/rust-cache`: `v1` → `v2` ([changelog](https://github.com/Swatinem/rust-cache/blob/v2/CHANGELOG.md))
- replace deprecated actions
  - `actions-rs/toolchain` → `dtolnay/rust-toolchain`
  - `actions-rs/cargo` → no action, used `cargo` command directly

If the https://github.com/standard-webhooks/standard-webhooks/issues/40 is resolved, this changes can be automated.

