### PR TITLE
feat(python): Update python lint configuration for tests

### DIFF
--- a/libraries/python/scripts/format.sh
+++ b/libraries/python/scripts/format.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -e
-set -x
+#!/usr/bin/env sh
+set -ex
 
-autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place standardwebhooks --exclude=__init__.py
-isort standardwebhooks
-black standardwebhooks
+autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place standardwebhooks tests --exclude=__init__.py
+isort standardwebhooks tests
+black standardwebhooks tests

--- a/libraries/python/scripts/lint.sh
+++ b/libraries/python/scripts/lint.sh
@@ -1,8 +1,7 @@
-#!/usr/bin/env bash
-
+#!/usr/bin/env sh
 set -ex
 
-mypy standardwebhooks
-isort --check-only standardwebhooks
-black standardwebhooks --check
-flake8 standardwebhooks
+mypy standardwebhooks tests
+isort --check-only standardwebhooks tests
+black standardwebhooks tests --check
+flake8 standardwebhooks tests

--- a/libraries/python/tests/test_webhooks.py
+++ b/libraries/python/tests/test_webhooks.py
@@ -1,32 +1,32 @@
-from time import timezone
-import pytest
 import base64
 import typing as t
-from math import floor
 from datetime import datetime, timedelta, timezone
+from math import floor
 
-from standardwebhooks.webhooks import hmac_data, Webhook, WebhookVerificationError
+import pytest
 
-defaultMsgID = 'msg_p5jXN8AQM9LWM0D4loKWxJek'
+from standardwebhooks.webhooks import Webhook, WebhookVerificationError, hmac_data
+
+defaultMsgID = "msg_p5jXN8AQM9LWM0D4loKWxJek"
 defaultPayload = '{"test": 2432232314}'
-defaultSecret = 'MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw'
+defaultSecret = "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
 
 tolerance = timedelta(minutes=5)
 
 
 class PayloadForTesting:
     id: str
-    timestamp: int
+    timestamp: str
     payload: str
     secret: str
     signature: str
     header: t.Dict[str, str]
 
-    def __init__(self, timestamp: datetime=datetime.now(tz=timezone.utc)):
+    def __init__(self, timestamp: datetime = datetime.now(tz=timezone.utc)):
         ts = str(floor(timestamp.timestamp()))
         to_sign = f"{defaultMsgID}.{ts}.{defaultPayload}".encode()
-        signature = base64.b64encode(hmac_data(base64.b64decode(defaultSecret), to_sign)).decode('utf-8')
-        
+        signature = base64.b64encode(hmac_data(base64.b64decode(defaultSecret), to_sign)).decode("utf-8")
+
         self.id = defaultMsgID
         self.timestamp = ts
         self.payload = defaultPayload
@@ -38,96 +38,106 @@ class PayloadForTesting:
             "webhook-timestamp": self.timestamp,
         }
 
-def test_missing_id_raises_error():
-    testPayload = PayloadForTesting()
-    del testPayload.header['webhook-id']
-    
-    wh = Webhook(testPayload.secret)
 
-    with pytest.raises(WebhookVerificationError):
-        wh.verify(testPayload.payload, testPayload.header)
-
-def test_timestamp_raises_error():
+def test_missing_id_raises_error() -> None:
     testPayload = PayloadForTesting()
-    del testPayload.header['webhook-timestamp'] 
+    del testPayload.header["webhook-id"]
 
     wh = Webhook(testPayload.secret)
 
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_invalid_timestamp_raises_error():
+
+def test_timestamp_raises_error() -> None:
     testPayload = PayloadForTesting()
-    testPayload.header['webhook-timestamp'] = 'hello'
+    del testPayload.header["webhook-timestamp"]
 
     wh = Webhook(testPayload.secret)
 
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_missing_signature_raises_error():
+
+def test_invalid_timestamp_raises_error() -> None:
     testPayload = PayloadForTesting()
-    del testPayload.header['webhook-signature']
+    testPayload.header["webhook-timestamp"] = "hello"
 
     wh = Webhook(testPayload.secret)
 
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_invalid_signature_raises_error():
+
+def test_missing_signature_raises_error() -> None:
     testPayload = PayloadForTesting()
-    testPayload.header['webhook-signature'] = 'v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OA='
+    del testPayload.header["webhook-signature"]
 
     wh = Webhook(testPayload.secret)
 
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_valid_signature_is_valid_and_returns_json():
+
+def test_invalid_signature_raises_error() -> None:
+    testPayload = PayloadForTesting()
+    testPayload.header["webhook-signature"] = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OA="
+
+    wh = Webhook(testPayload.secret)
+
+    with pytest.raises(WebhookVerificationError):
+        wh.verify(testPayload.payload, testPayload.header)
+
+
+def test_valid_signature_is_valid_and_returns_json() -> None:
     testPayload = PayloadForTesting()
 
     wh = Webhook(testPayload.secret)
 
     json = wh.verify(testPayload.payload, testPayload.header)
-    assert json['test'] == 2432232314
+    assert json["test"] == 2432232314
 
-def test_valid_unbranded_signature_is_valid_and_returns_json():
+
+def test_valid_unbranded_signature_is_valid_and_returns_json() -> None:
     testPayload = PayloadForTesting()
+
     unbrandedHeaders = {
-        "webhook-id": testPayload.header.get("webhook-id"),
-        "webhook-signature": testPayload.header.get("webhook-signature"),
-        "webhook-timestamp": testPayload.header.get("webhook-timestamp")
+        "webhook-id": testPayload.header["webhook-id"],
+        "webhook-signature": testPayload.header["webhook-signature"],
+        "webhook-timestamp": testPayload.header["webhook-timestamp"],
     }
     testPayload.header = unbrandedHeaders
 
     wh = Webhook(testPayload.secret)
 
     json = wh.verify(testPayload.payload, testPayload.header)
-    assert json['test'] == 2432232314
+    assert json["test"] == 2432232314
 
 
-def test_old_timestamp_fails():
+def test_old_timestamp_fails() -> None:
     testPayload = PayloadForTesting(datetime.now(tz=timezone.utc) - tolerance - timedelta(seconds=1))
-    
+
     wh = Webhook(testPayload.secret)
 
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_new_timestamp_fails():
+
+def test_new_timestamp_fails() -> None:
     testPayload = PayloadForTesting(datetime.now(tz=timezone.utc) + tolerance + timedelta(seconds=1))
 
-    wh = Webhook(testPayload.secret)    
-    
+    wh = Webhook(testPayload.secret)
+
     with pytest.raises(WebhookVerificationError):
         wh.verify(testPayload.payload, testPayload.header)
 
-def test_multi_sig_payload_is_valid():
+
+def test_multi_sig_payload_is_valid() -> None:
     testPayload = PayloadForTesting()
     sigs = [
         "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
         "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
-        testPayload.header["webhook-signature"], # valid signature
+        testPayload.header["webhook-signature"],  # valid signature
         "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
     ]
     testPayload.header["webhook-signature"] = " ".join(sigs)
@@ -137,7 +147,8 @@ def test_multi_sig_payload_is_valid():
     json = wh.verify(testPayload.payload, testPayload.header)
     assert json["test"] == 2432232314
 
-def test_signature_verification_with_and_without_prefix():
+
+def test_signature_verification_with_and_without_prefix() -> None:
     testPayload = PayloadForTesting()
 
     wh = Webhook(testPayload.secret)
@@ -149,7 +160,8 @@ def test_signature_verification_with_and_without_prefix():
     json = wh.verify(testPayload.payload, testPayload.header)
     assert json["test"] == 2432232314
 
-def test_sign_function():
+
+def test_sign_function() -> None:
     key = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
     msg_id = "msg_p5jXN8AQM9LWM0D4loKWxJek"
     timestamp = datetime.utcfromtimestamp(1614265330)


### PR DESCRIPTION
This PR includes the following changes:

- Updated shell scripts shebang
  - `./libraries/python/scripts/format.sh`
    - `#!/bin/sh -e; set -x` → `#!/usr/bin/env sh; set -ex`
  - `./libraries/python/scripts/lint.sh`
    - `#!/usr/bin/env bash` → `#!/usr/bin/env sh`
- Make lint, format to include `tests` directory
  - `autoflake`, `isort`, `black`, `flake8`, and `mypy`
- Fix type hints
  - `PayloadForTesting.timestamp`: `int` → `str`
  - `test_valid_unbranded_signature_is_valid_and_returns_json#unbrandedHeaders`: assert not null dict values
  - Add test methods' return types as `None`
- Remove duplicate `timezone` import (`from time import timezone`)