### PR TITLE
feat(python): Improve python build-system

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -24,14 +24,14 @@ jobs:
           python -m pip install -r requirements-dev.txt .
         working-directory: libraries/python
 
-      - name: Install setuptools
+      - name: Install build
         run: |
-          python -m pip install setuptools
+          pip install build~=1.0.3
         working-directory: libraries/python
 
       - name: Build sdist
         run: |
-          python setup.py sdist
+          pyproject-build . --sdist
         working-directory: libraries/python
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+build-backend = "setuptools.build_meta:__legacy__"
+requires = ["setuptools >= 40.8.0", "wheel"]
+
 [tool.black]
 line-length = 120
 

--- a/libraries/python/requirements.txt
+++ b/libraries/python/requirements.txt
@@ -1,3 +1,2 @@
 python_dateutil >= 2.5.3
-setuptools >= 21.0.0
 types-python-dateutil >= 2.8.9

--- a/libraries/python/setup.py
+++ b/libraries/python/setup.py
@@ -5,10 +5,7 @@ from setuptools import setup, find_packages  # noqa: H301
 
 # To install the library, run the following
 #
-# python setup.py install
-#
-# prerequisite: setuptools
-# http://pypi.python.org/pypi/setuptools
+# pip install .
 
 
 def read_file(filepath):


### PR DESCRIPTION
Resolves #47

This PR includes the following changes:

- Use `build~=1.0.3` instead of `python setup.py sdist`
- Add `build-system` to `pyproject.toml`
  - Same as default ([`build/__init__.py`](https://github.com/pypa/build/blob/1.0.3/src/build/__init__.py#L50-L53), and [PEP 517](https://peps.python.org/pep-0517/))
  ```python
  _DEFAULT_BACKEND = {
      'build-backend': 'setuptools.build_meta:__legacy__',
      'requires': ['setuptools >= 40.8.0', 'wheel'],
  }
  ```
- Remove `setuptools` from `requirements.txt`
- Update `setup.py` comment