### PR TITLE
chore(php): fix link to homepage in composer.json

### DIFF
--- a/libraries/composer.json
+++ b/libraries/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Standard Webhooks PHP Library",
     "keywords": ["webhooks"],
-    "homepage": "https://github.com/standard-webhooks/libraries",
+    "homepage": "https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/php",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The `homepage` property in `composer.json` led to a 404 page on GitHub: https://github.com/standard-webhooks/libraries. This PR fixes that.