### PR TITLE
feat(python): Use `ruff` for linter and formatter

### DIFF
--- a/libraries/python/.flake8
+++ b/libraries/python/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-extend-ignore = E203, W503, E501, E711, E712, N803
-exclude = .git,__pycache__,__init__.py,.mypy_cache,.pytest_cache

--- a/libraries/python/mypy.ini
+++ b/libraries/python/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-strict = True

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -2,14 +2,15 @@
 build-backend = "setuptools.build_meta:__legacy__"
 requires = ["setuptools >= 40.8.0", "wheel"]
 
-[tool.black]
+[tool.mypy]
+strict = true
+
+[tool.ruff]
 line-length = 120
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 120
-skip_gitignore = true
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "T20", "W"]
+ignore = ["E203", "E501", "E711", "E712", "N803"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true

--- a/libraries/python/requirements-dev.txt
+++ b/libraries/python/requirements-dev.txt
@@ -4,65 +4,33 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements.in/development.txt
 #
-autoflake==2.2.1
-    # via -r requirements.in/development.txt
-black==23.7.0
-    # via -r requirements.in/development.txt
-build==1.0.0
+build==1.0.3
     # via pip-tools
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
-flake8==6.1.0
-    # via
-    #   -r requirements.in/development.txt
-    #   flake8-print
-    #   pep8-naming
-flake8-print==5.0.0
-    # via -r requirements.in/development.txt
+    # via pip-tools
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
-    # via -r requirements.in/development.txt
-mccabe==0.7.0
-    # via flake8
-mypy==1.5.1
+mypy==1.7.1
     # via -r requirements.in/development.txt
 mypy-extensions==1.0.0
+    # via mypy
+packaging==23.2
     # via
-    #   black
-    #   mypy
-packaging==23.1
-    # via
-    #   black
     #   build
     #   pytest
-pathspec==0.11.2
-    # via black
-pep8-naming==0.13.3
-    # via -r requirements.in/development.txt
 pip-tools==7.3.0
     # via -r requirements.in/development.txt
-platformdirs==3.10.0
-    # via black
 pluggy==1.3.0
     # via pytest
-pycodestyle==2.11.0
-    # via
-    #   flake8
-    #   flake8-print
-pyflakes==3.1.0
-    # via
-    #   autoflake
-    #   flake8
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.1
+pytest==7.4.3
     # via -r requirements.in/development.txt
-typing-extensions==4.7.1
+ruff==0.1.8
+    # via -r requirements.in/development.txt
+typing-extensions==4.9.0
     # via mypy
-wheel==0.41.2
+wheel==0.42.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/libraries/python/requirements.in/development.txt
+++ b/libraries/python/requirements.in/development.txt
@@ -1,9 +1,4 @@
-autoflake
-black
-isort
-flake8
-flake8-print
-pep8-naming
 mypy>=1.4.0
 pip-tools>=6.13.0
 pytest
+ruff>=0.1.8

--- a/libraries/python/scripts/format.sh
+++ b/libraries/python/scripts/format.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 set -ex
 
-autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place standardwebhooks tests --exclude=__init__.py
-isort standardwebhooks tests
-black standardwebhooks tests
+ruff check --fix .
+ruff format .

--- a/libraries/python/scripts/lint.sh
+++ b/libraries/python/scripts/lint.sh
@@ -2,6 +2,5 @@
 set -ex
 
 mypy standardwebhooks tests
-isort --check-only standardwebhooks tests
-black standardwebhooks tests --check
-flake8 standardwebhooks tests
+ruff check .
+ruff format --check .

--- a/libraries/python/setup.cfg
+++ b/libraries/python/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length=120
-extend-ignore=E203

--- a/libraries/python/setup.py
+++ b/libraries/python/setup.py
@@ -1,7 +1,8 @@
+import codecs
 import os
 import re
-import codecs
-from setuptools import setup, find_packages  # noqa: H301
+
+from setuptools import find_packages, setup
 
 # To install the library, run the following
 #


### PR DESCRIPTION
This PR includes the following changes:

- Use `ruff` as a linter
  - `autoflake` → `ruff`'s rule (`F`)
  - `flake8` → `ruff`'s rule (`E`, `W`)
  - `flake8-print` → `ruff`'s rule (`T20`)
  - `isort` → `ruff`'s rule (`I`)
  - `pep8-naming` → `ruff`'s rule (`N`)
- Use `ruff` as a formatter
  - `black` → `ruff format`
- Use `pyproject.toml` for tool configurations
  - `mypy.ini` → `pyproject.toml` (`tool.mypy`)

Many open source python projects are using [`ruff`](https://docs.astral.sh/ruff/rules/). `ruff` has rules that are fully compatible with existing linters such as `pylint`, `flake8`, `isort`, etc., while being much faster. The `ruff` formatter compatible with black is also provided. (production-ready beta, but with some [known differences](https://docs.astral.sh/ruff/formatter/black/))

One of the advantages is that it has zero runtime-dependency. Written in rust, the dependencies are built into a single binary, and when installed as a python package, it can be installed and used very quickly without additional dependencies.

Also, `flake8` has no plan to support `pyproject.toml` ([PEP 518](https://peps.python.org/pep-0518/)) for the time being. (https://github.com/PyCQA/flake8/issues/234)

Since this PR replaces existing, working tools for faster performance and cleaner configuration, it is okay to review slowly and carefully and leave any comments :)