### PR TITLE
ci: ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,35 +4,71 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: gomod
   directory:  /libraries
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: npm
   directory: /libraries/javascript
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: pip
   directory: /libraries/python
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: cargo
   directory: /libraries/rust
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: gradle
   directory: /libraries/java
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: composer
   directory: /libraries
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: nuget
   directory: /libraries/csharp
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: bundler
   directory: /libraries/ruby
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "*"
+    update-types:
+      - "version-update:semver-patch"


### PR DESCRIPTION
We want to ignore patch releases otherwise we can get completely overwelmed by those PRs. If there's a security issue this will bubble up in the `Security` tab of the repository