### PR TITLE
refactor(php): stop using `ctype_digit` for positive integer check

### DIFF
--- a/libraries/php/src/Webhook.php
+++ b/libraries/php/src/Webhook.php
@@ -63,7 +63,7 @@ class Webhook
     public function sign($msgId, $timestamp, $payload)
     {
         $timestamp = (string) $timestamp;
-        $is_positive_integer = ctype_digit($timestamp);
+        $is_positive_integer = self::isPositiveInteger($timestamp);
         if (!$is_positive_integer) {
             throw new Exception\WebhookSigningException("Invalid timestamp");
         }
@@ -89,5 +89,10 @@ class Webhook
             throw new Exception\WebhookVerificationException("Message timestamp too new");
         }
         return $timestamp;
+    }
+
+    private function isPositiveInteger($v)
+    {
+        return is_numeric($v) && !is_float($v + 0) && (int) $v == $v && (int) $v > 0;
     }
 }


### PR DESCRIPTION
A similar change was recently made to the `svix-webhooks` PHP lib, thanks to a user contribution.

Motivated by a deprecation warning for PHP 8.1, where there's a behavior change for non-string arguments to `ctype_digit`.

Refs:
- <https://github.com/svix/svix-webhooks/pull/1355>
- <https://github.com/svix/svix-webhooks/pull/1356>