### PR TITLE
Ruby adjustments

### DIFF
--- a/libraries/ruby/.editorconfig
+++ b/libraries/ruby/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 120
+
+[{*.diff,*.md}]
+trim_trailing_whitespace = false

--- a/libraries/ruby/lib/standardwebhooks/errors.rb
+++ b/libraries/ruby/lib/standardwebhooks/errors.rb
@@ -5,7 +5,7 @@ module StandardWebhooks
     attr_reader :message
 
     def initialize(message = nil)
-        @message = message
+      @message = message
     end
   end
 

--- a/libraries/ruby/lib/standardwebhooks/errors.rb
+++ b/libraries/ruby/lib/standardwebhooks/errors.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 module StandardWebhooks
-    class StandardWebhooksError < StandardError
-        attr_reader :message
+  class StandardWebhooksError < StandardError
+    attr_reader :message
 
-        def initialize(message = nil)
-            @message = message
-        end
+    def initialize(message = nil)
+        @message = message
     end
+  end
 
-    class WebhookVerificationError < StandardWebhooksError
-    end
+  class WebhookVerificationError < StandardWebhooksError
+  end
 
-    class WebhookSigningError < StandardWebhooksError
-    end
+  class WebhookSigningError < StandardWebhooksError
+  end
 end

--- a/libraries/ruby/lib/standardwebhooks/util.rb
+++ b/libraries/ruby/lib/standardwebhooks/util.rb
@@ -22,6 +22,7 @@ module StandardWebhooks
       res == 0
     end
   end
+
   module_function :fixed_length_secure_compare
 
   # Secure string comparison for strings of variable length.
@@ -33,5 +34,6 @@ module StandardWebhooks
   def secure_compare(a, b)
     a.length == b.length && fixed_length_secure_compare(a, b)
   end
+
   module_function :secure_compare
 end

--- a/libraries/ruby/lib/standardwebhooks/util.rb
+++ b/libraries/ruby/lib/standardwebhooks/util.rb
@@ -7,31 +7,31 @@
 # The values compared should be of fixed length, such as strings
 # that have already been processed by HMAC. Raises in case of length mismatch.
 module StandardWebhooks
-    if defined?(OpenSSL.fixed_length_secure_compare)
-        def fixed_length_secure_compare(a, b)
-            OpenSSL.fixed_length_secure_compare(a, b)
-        end
-        else
-        def fixed_length_secure_compare(a, b)
-            raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize
-
-            l = a.unpack "C#{a.bytesize}"
-
-            res = 0
-            b.each_byte { |byte| res |= byte ^ l.shift }
-            res == 0
-        end
+  if defined?(OpenSSL.fixed_length_secure_compare)
+    def fixed_length_secure_compare(a, b)
+      OpenSSL.fixed_length_secure_compare(a, b)
     end
-    module_function :fixed_length_secure_compare
+  else
+    def fixed_length_secure_compare(a, b)
+      raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize
 
-    # Secure string comparison for strings of variable length.
-    #
-    # While a timing attack would not be able to discern the content of
-    # a secret compared via secure_compare, it is possible to determine
-    # the secret length. This should be considered when using secure_compare
-    # to compare weak, short secrets to user input.
-    def secure_compare(a, b)
-        a.length == b.length && fixed_length_secure_compare(a, b)
+      l = a.unpack "C#{a.bytesize}"
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
     end
-    module_function :secure_compare
+  end
+  module_function :fixed_length_secure_compare
+
+  # Secure string comparison for strings of variable length.
+  #
+  # While a timing attack would not be able to discern the content of
+  # a secret compared via secure_compare, it is possible to determine
+  # the secret length. This should be considered when using secure_compare
+  # to compare weak, short secrets to user input.
+  def secure_compare(a, b)
+    a.length == b.length && fixed_length_secure_compare(a, b)
+  end
+  module_function :secure_compare
 end

--- a/libraries/ruby/lib/standardwebhooks/webhooks.rb
+++ b/libraries/ruby/lib/standardwebhooks/webhooks.rb
@@ -14,7 +14,7 @@ module StandardWebhooks
 
     def initialize(secret)
       if secret.start_with?(SECRET_PREFIX)
-          secret = secret[SECRET_PREFIX.length..-1]
+        secret = secret[SECRET_PREFIX.length..-1]
       end
 
       @secret = Base64.decode64(secret)

--- a/libraries/ruby/lib/standardwebhooks/webhooks.rb
+++ b/libraries/ruby/lib/standardwebhooks/webhooks.rb
@@ -6,74 +6,74 @@ require "base64"
 require "uri"
 
 module StandardWebhooks
-    class Webhook
+  class Webhook
 
-        def self.new_using_raw_bytes(secret)
-            self.new(secret.pack("C*").force_encoding("UTF-8"))
-        end
-
-        def initialize(secret)
-            if secret.start_with?(SECRET_PREFIX)
-                secret = secret[SECRET_PREFIX.length..-1]
-            end
-
-            @secret = Base64.decode64(secret)
-        end
-
-        def verify(payload, headers)
-              msgId = headers["webhook-id"]
-              msgSignature = headers["webhook-signature"]
-              msgTimestamp = headers["webhook-timestamp"]
-              if !msgSignature || !msgId || !msgTimestamp
-                  raise WebhookVerificationError, "Missing required headers"
-              end
-
-            verify_timestamp(msgTimestamp)
-
-            _, signature = sign(msgId, msgTimestamp, payload).split(",", 2)
-
-            passedSignatures = msgSignature.split(" ")
-            passedSignatures.each do |versionedSignature|
-                version, expectedSignature = versionedSignature.split(",", 2)
-                if version != "v1"
-                    next
-                end
-                if ::StandardWebhooks::secure_compare(signature, expectedSignature)
-                    return JSON.parse(payload, symbolize_names: true)
-                end
-            end
-            raise WebhookVerificationError, "No matching signature found"
-        end
-
-        def sign(msgId, timestamp, payload)
-            begin
-                now = Integer(timestamp)
-            rescue
-                raise WebhookSigningError, "Invalid timestamp"
-            end
-            toSign = "#{msgId}.#{timestamp}.#{payload}"
-            signature = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), @secret, toSign)).strip
-            return "v1,#{signature}"
-        end
-
-        private
-        SECRET_PREFIX = "whsec_"
-        TOLERANCE = 5 * 60
-
-        def verify_timestamp(timestampHeader)
-            begin
-                now = Integer(Time.now)
-                timestamp = Integer(timestampHeader)
-            rescue
-                raise WebhookVerificationError, "Invalid Signature Headers"
-            end
-
-            if timestamp < (now - TOLERANCE)
-                raise WebhookVerificationError, "Message timestamp too old"
-            end
-            if timestamp > (now + TOLERANCE)
-                raise WebhookVerificationError, "Message timestamp too new"
-            end
-        end
+    def self.new_using_raw_bytes(secret)
+      self.new(secret.pack("C*").force_encoding("UTF-8"))
     end
+
+    def initialize(secret)
+      if secret.start_with?(SECRET_PREFIX)
+          secret = secret[SECRET_PREFIX.length..-1]
+      end
+
+      @secret = Base64.decode64(secret)
+    end
+
+    def verify(payload, headers)
+      msgId = headers["webhook-id"]
+      msgSignature = headers["webhook-signature"]
+      msgTimestamp = headers["webhook-timestamp"]
+      if !msgSignature || !msgId || !msgTimestamp
+        raise WebhookVerificationError, "Missing required headers"
+      end
+
+      verify_timestamp(msgTimestamp)
+
+      _, signature = sign(msgId, msgTimestamp, payload).split(",", 2)
+
+      passedSignatures = msgSignature.split(" ")
+      passedSignatures.each do |versionedSignature|
+        version, expectedSignature = versionedSignature.split(",", 2)
+        if version != "v1"
+          next
+        end
+        if ::StandardWebhooks::secure_compare(signature, expectedSignature)
+          return JSON.parse(payload, symbolize_names: true)
+        end
+      end
+      raise WebhookVerificationError, "No matching signature found"
+    end
+
+    def sign(msgId, timestamp, payload)
+      begin
+        now = Integer(timestamp)
+      rescue
+        raise WebhookSigningError, "Invalid timestamp"
+      end
+      toSign = "#{msgId}.#{timestamp}.#{payload}"
+      signature = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), @secret, toSign)).strip
+      return "v1,#{signature}"
+    end
+
+    private
+    SECRET_PREFIX = "whsec_"
+    TOLERANCE = 5 * 60
+
+    def verify_timestamp(timestampHeader)
+      begin
+        now = Integer(Time.now)
+        timestamp = Integer(timestampHeader)
+      rescue
+        raise WebhookVerificationError, "Invalid Signature Headers"
+      end
+
+      if timestamp < (now - TOLERANCE)
+        raise WebhookVerificationError, "Message timestamp too old"
+      end
+      if timestamp > (now + TOLERANCE)
+        raise WebhookVerificationError, "Message timestamp too new"
+      end
+    end
+  end
 end

--- a/libraries/ruby/standardwebhooks.gemspec
+++ b/libraries/ruby/standardwebhooks.gemspec
@@ -28,10 +28,8 @@ Gem::Specification.new do |spec|
     /\A.gitignore/,
     /.gem\z/
   )
-  spec.files = Dir['**/*'].reject {|f| !File.file?(f) || ignored.match(f) }
 
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir['**/*'].reject {|f| !File.file?(f) || ignored.match(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", ">= 2.2.10"


### PR DESCRIPTION
These are some ruby code style adjustments, to make the code base better with how
code is written in the ruby community.

There should be zero functional changes in here, it's just white space and variable naming.

There are also a few non-functional code changes I could suggest, such as another way to define private constants, a few more changes to the gemspec file and adding a minimum ruby version (I'd suggest 3.1 or 3.0 as the minimum[1]).

However, I'll leave that for another PR, assuming you are open to such changes.

There is also both `secure_compare` and `fixed_with_secure_compare` in the Ruby OpenSSL library[2]. The difference is that the former will hash to ensure fixed length. But if both have fixed length, then there is no need.

What's the case here? Are we certain the two are fixed and identical length already? Otherwise we should consider switching to `secure_compare`.

(note that this is already what the 'fallback' implementation guards against: `raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize`)


Fixes #158

[1] https://github.com/standard-webhooks/standard-webhooks/issues/158
[2] https://github.com/ruby/openssl/pull/280