### PR TITLE
README: add link to Swift library

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ There are reference implementations for the signature verification theme for a v
 
 - [Java](https://github.com/Cosium/standard-webhooks-consumer)
 - [C# (.NET)](https://github.com/codefactors/StandardWebhooks)
+- [Swift](https://github.com/m1guelpf/swift-standard-webhooks)
 
 
 ## Technical steering committee


### PR DESCRIPTION
I've made a Swift library for both signing and validating webhooks according to the spec. Both the implementation and the test suite match the official Rust implementation, while adopting Swift idiomatics.