### PR TITLE
fix: remove not needed Python dependencies

### DIFF
--- a/libraries/python/requirements.txt
+++ b/libraries/python/requirements.txt
@@ -1,2 +1,0 @@
-python_dateutil >= 2.5.3
-types-python-dateutil >= 2.8.9

--- a/libraries/python/setup.py
+++ b/libraries/python/setup.py
@@ -19,14 +19,6 @@ PKG_NAME = "standardwebhooks"
 PKG_DIR = os.path.abspath(os.path.dirname(__file__))
 META_PATH = os.path.join(PKG_DIR, PKG_NAME, "__init__.py")
 META_CONTENTS = read_file(META_PATH)
-PKG_REQUIRES = [
-    "httpx >=0.23.0",
-    "attrs >=21.3.0",
-    "python-dateutil",
-    "Deprecated",
-    "types-python-dateutil",
-    "types-Deprecated",
-]
 
 
 def find_meta(meta):
@@ -95,7 +87,6 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     python_requires=">=3.6",
-    install_requires=PKG_REQUIRES,
     zip_safe=False,
     packages=find_packages(exclude=["test", "tests"]),
     package_data={


### PR DESCRIPTION
The code does not import any third-party code, so there is no need to declare these as dependencies.