### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "standard-webhooks/standard-webhooks",
+    "description": "Standard Webhooks - Open source tools and guidelines for sending webhooks easily, securely, and reliably",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "webhooks",
+        "signature",
+        "verification",
+        "hmac",
+        "standard-webhooks"
+    ],
+    "homepage": "https://www.standardwebhooks.com",
+    "require": {
+        "php": "^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "StandardWebhooks\\": "libraries/php/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "StandardWebhooks\\Tests\\": "libraries/php/tests/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.0 || ^10.0"
+    }
+}


### PR DESCRIPTION
The `composer.json` file is needed to publish the PHP package to packagist

part of: https://github.com/standard-webhooks/standard-webhooks/issues/249

 