### PR TITLE
feat(libraries/javascript): switch to safer libs

### DIFF
--- a/libraries/javascript/package.json
+++ b/libraries/javascript/package.json
@@ -27,11 +27,10 @@
     "lint:fix": "yarn run lint:prettier --write && yarn run lint:eslint --fix"
   },
   "dependencies": {
-    "@stablelib/base64": "^2.0.0",
-    "fast-sha256": "^1.3.0"
+    "@exodus/bytes": "^1.10.0",
+    "@noble/hashes": "^2.0.1"
   },
   "devDependencies": {
-    "@stablelib/utf8": "^2.0.0",
     "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",

--- a/libraries/javascript/src/index.ts
+++ b/libraries/javascript/src/index.ts
@@ -1,6 +1,9 @@
 import { timingSafeEqual } from "./timing_safe_equal";
-import * as base64 from "@stablelib/base64";
-import * as sha256 from "fast-sha256";
+import { fromBase64, toBase64 } from "@exodus/bytes/base64.js";
+import { latin1fromString } from "@exodus/bytes/single-byte.js";
+import { utf8fromString } from "@exodus/bytes/utf8.js";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha256 } from "@noble/hashes/sha2.js";
 
 const WEBHOOK_TOLERANCE_IN_SECONDS = 5 * 60; // 5 minutes
 
@@ -43,7 +46,7 @@ export class Webhook {
       if (secret instanceof Uint8Array) {
         this.key = secret;
       } else {
-        this.key = Uint8Array.from(secret, (c) => c.charCodeAt(0));
+        this.key = latin1fromString(secret);
       }
     } else {
       if (typeof secret !== "string") {
@@ -52,7 +55,7 @@ export class Webhook {
       if (secret.startsWith(Webhook.prefix)) {
         secret = secret.substring(Webhook.prefix.length);
       }
-      this.key = base64.decode(secret);
+      this.key = fromBase64(secret);
     }
   }
 
@@ -80,14 +83,13 @@ export class Webhook {
 
     const passedSignatures = msgSignature.split(" ");
 
-    const encoder = new globalThis.TextEncoder();
     for (const versionedSignature of passedSignatures) {
       const [version, signature] = versionedSignature.split(",");
       if (version !== "v1") {
         continue;
       }
 
-      if (timingSafeEqual(encoder.encode(signature), encoder.encode(expectedSignature))) {
+      if (timingSafeEqual(utf8fromString(signature), utf8fromString(expectedSignature))) {
         return JSON.parse(payload.toString());
       }
     }
@@ -103,10 +105,9 @@ export class Webhook {
       throw new Error("Expected payload to be of type string or Buffer.");
     }
 
-    const encoder = new TextEncoder();
     const timestampNumber = Math.floor(timestamp.getTime() / 1000);
-    const toSign = encoder.encode(`${msgId}.${timestampNumber}.${payload}`);
-    const expectedSignature = base64.encode(sha256.hmac(this.key, toSign));
+    const toSign = utf8fromString(`${msgId}.${timestampNumber}.${payload}`);
+    const expectedSignature = toBase64(hmac(sha256, this.key, toSign));
     return `v1,${expectedSignature}`;
   }
 

--- a/libraries/javascript/src/webhook.test.ts
+++ b/libraries/javascript/src/webhook.test.ts
@@ -1,6 +1,7 @@
-import * as utf8 from "@stablelib/utf8";
-import * as base64 from "@stablelib/base64";
-import * as sha256 from "fast-sha256";
+import { utf8fromString } from "@exodus/bytes/utf8.js";
+import { fromBase64, toBase64 } from "@exodus/bytes/base64.js";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha256 } from "@noble/hashes/sha2.js";
 
 import { Webhook, WebhookVerificationError } from "./index";
 
@@ -25,8 +26,8 @@ class TestPayload {
     this.payload = defaultPayload;
     this.secret = defaultSecret;
 
-    const toSign = utf8.encode(`${this.id}.${this.timestamp}.${this.payload}`);
-    this.signature = base64.encode(sha256.hmac(base64.decode(this.secret), toSign));
+    const toSign = utf8fromString(`${this.id}.${this.timestamp}.${this.payload}`);
+    this.signature = toBase64(hmac(sha256, fromBase64(this.secret), toSign));
 
     this.header = {
       "webhook-id": this.id,

--- a/libraries/javascript/yarn.lock
+++ b/libraries/javascript/yarn.lock
@@ -466,6 +466,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.4.tgz#9e69f8bb4031e11df79e03db09f9dbbae1740843"
   integrity sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==
 
+"@exodus/bytes@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.10.0.tgz#5d5f5b90152a65c1a58079e427f9e7a6e951165a"
+  integrity sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==
+
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
@@ -724,6 +729,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@noble/hashes@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.0.1.tgz#fc1a928061d1232b0a52bb754393c37a5216c89e"
+  integrity sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -765,14 +775,14 @@
     "@sinonjs/commons" "^3.0.0"
 
 "@stablelib/base64@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-2.0.0.tgz#f13a98549cd5ca0750cd177bbd08b599d24e5f8e"
-  integrity sha512-ffSfySa1ZpZYzM5FQ2xILQ2jifQ+GlgbDJzRTCtaB0sqta88KYghB/tlSV2VS2iHRCvMdUvJlLOW1rmSkziWnw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-2.0.1.tgz#f1546ab26896b3490d1ab531373c0dc39e12cee1"
+  integrity sha512-P2z89A7N1ETt6RxgpVdDT2xlg8cnm3n6td0lY9gyK7EiWK3wdq388yFX/hLknkCC0we05OZAD1rfxlQJUbl5VQ==
 
 "@stablelib/utf8@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stablelib/utf8/-/utf8-2.0.0.tgz#05725ef9d39ed10a017e1b6e01374bd998c83167"
-  integrity sha512-bHaUduwFKYgj6rRvA5udyyg+ASx6gJZiQaXvfBHb7A2r+X9tRIKJ/VmpQKFQnEMInpBTh7jJLy+Gt99GH9YZ9g==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/utf8/-/utf8-2.0.1.tgz#3693310a5013cdcf92ed0bd763c8a278db6fee07"
+  integrity sha512-7+C2Iap42fbLyoKMaEIIDSb1TrcQVo+lGDItYAwb2JoAJr7QffyuDnbtvV/qzTyokOIMBrJgT+Rpsp1bPR8SjA==
 
 "@types/babel__core@^7.1.14":
   version "7.20.1"


### PR DESCRIPTION
1. Replace `fast-sha265` with [@noble/hashes](https://npmjs.com/package/@noble/hashes)
2. Replace `@stablelib/base64`, `@stablelib/utf8`, lossy `TextEncoder` and manual latin1 parsing with [@exodus/bytes](https://npmjs.com/package/@exodus/bytes)

### Why?

1. `@noble/hashes` is a widely adopted and independently audited clean and fast hashes implementation by http://github.com/paulmillr
2. `new TextEncoder().encode(string)` implicitly casts [DOMString](https://webidl.spec.whatwg.org/#idl-DOMString) to [USVString](https://webidl.spec.whatwg.org/#idl-USVString), causing non-well-formed ECMAScript strings to be replaced, causing [collisions](https://github.com/nodejs/node/issues/60267) on non-well-formed strings that can survive being passed over JSON and network, and is not suitable for cryptography applications
3. `@stablelib/` is inconsistent, see e.g. https://github.com/StableLib/stablelib/issues/81, and very slow
4. On all modern platforms, `@exodus/bytes/base64.js` just uses the native implementation with extra validation, so it's very fast (as other methods there), no need to go the manual js codepath
5. Raw secret parsing used here was lossy. `Uint8Array.from(secret, (c) => c.charCodeAt(0));` does not perform any input validation and returns e.g. `Uint8Array [ 83, 147, 107, 97, 111 ]` on. `'こんにちは'`, which is not what is expected. `latin1fromString` is validating instead, and throws on any codepoints higher that `U+00FF` and on non-well-formed strings


_Disclaimer: I'm the author of `@exodus/bytes`_