### PR TITLE
fix(js): handle empty payloads in verify()

### DIFF
--- a/libraries/javascript/src/index.ts
+++ b/libraries/javascript/src/index.ts
@@ -88,7 +88,11 @@ export class Webhook {
       }
 
       if (timingSafeEqual(encoder.encode(signature), encoder.encode(expectedSignature))) {
-        return JSON.parse(payload.toString());
+        const payloadString = payload.toString();
+        if (payloadString === "") {
+          return undefined;
+        }
+        return JSON.parse(payloadString);
       }
     }
     throw new WebhookVerificationError("No matching signature found");

--- a/libraries/javascript/src/webhook.test.ts
+++ b/libraries/javascript/src/webhook.test.ts
@@ -202,3 +202,23 @@ test("sign function works", () => {
   const signature = wh.sign(msgId, timestamp, payload);
   expect(signature).toBe(expected);
 });
+
+test("empty payload returns undefined", () => {
+  const wh = new Webhook(defaultSecret);
+
+  const msgId = defaultMsgID;
+  const timestamp = Math.floor(Date.now() / 1000);
+  const payload = "";
+
+  const toSign = utf8.encode(`${msgId}.${timestamp}.${payload}`);
+  const signature = base64.encode(sha256.hmac(base64.decode(defaultSecret), toSign));
+
+  const header = {
+    "webhook-id": msgId,
+    "webhook-signature": "v1," + signature,
+    "webhook-timestamp": timestamp.toString(),
+  };
+
+  const result = wh.verify(payload, header);
+  expect(result).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- Return `undefined` for empty payloads instead of calling `JSON.parse()`, which throws a `SyntaxError` on empty strings

## Problem

The `verify()` function always calls `JSON.parse(payload.toString())` after signature verification succeeds. This causes a `SyntaxError` when verifying requests with empty payloads, which is common for GET requests.

Real-world example: recall.ai uses GET requests with empty payloads, making it impossible to use this library with their API.

Fixes #262