### PR TITLE
publish a wheel

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pyproject-build . --sdist
+          pyproject-build .
         working-directory: libraries/python
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Else every user has to build the wheel at install time.  Better for maintainers to build the wheel once, and publish it