### PR TITLE
fix(release): fix ruby release script

### DIFF
--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p "$HOME/.gem"
           touch "$HOME/.gem/credentials"
           chmod 0600 "$HOME/.gem/credentials"
-          printf -- "---\n:rubygems_api_key: %s\n" "$RUBYGEMS_AUTH_TOKEN" > "$HOME/.gem/credentials"
+          printf "---\n:rubygems_api_key: %s\n" "$RUBYGEMS_AUTH_TOKEN" > "$HOME/.gem/credentials"
 
           gem push pkg/*.gem
         env:


### PR DESCRIPTION
The `printf` utility will read the first argument, which is in this case `--`, and print that. Removing this prints a correct credentials file.

The Ruby release action seems to be failing at `gem push` due to not having credentials. I hope that this fix will fix that.