### PR TITLE
C# lib: switch to trusted publishing + change package name

### DIFF
--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -32,11 +32,17 @@ jobs:
           dotnet build --configuration Release StandardWebhooks --no-restore
         working-directory: libraries/csharp
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Release
         run: |
           dotnet nuget push "$(find StandardWebhooks/bin/Release/StandardWebhooks.*.nupkg)" \
             --api-key "$NUGET_API_KEY" \
             --source "https://api.nuget.org/v3/index.json"
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
         working-directory: libraries/csharp

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ The human-readable markdown file is the source of truth for the specification.
 
 There are reference implementations for the signature verification theme for a variety of languages, including:
 
-- [Python](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/python)
-- [JavaScript/TypeScript](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/javascript)
-- [Java/Kotlin](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/java)
-- [Rust](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/rust)
-- [Go](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/go)
-- [Ruby](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/ruby)
+- [Python](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/python) - `standardwebhooks` on PyPi.
+- [JavaScript/TypeScript](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/javascript) - `standardwebhooks` on NPM.
+- [Java/Kotlin](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/java) - `com.standardwebhooks:standardwebhooks` on Maven Central.
+- [Rust](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/rust) - `standardwebhooks` on crates.io.
+- [Go](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/go) - `github.com/standard-webhooks/standard-webhooks/libraries/go` as a Go module.
+- [Ruby](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/ruby) - `standardwebhooks` on RubyGems.
 - [PHP](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/php)
-- [C#](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/csharp)
+- [C#](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/csharp) - `StandardWebhooks.StandardWebhooks` on nuget.
 - [Elixir](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries/elixir)
 
 ## Community implementations

--- a/libraries/csharp/StandardWebhooks/StandardWebhooks.csproj
+++ b/libraries/csharp/StandardWebhooks/StandardWebhooks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
-    <PackageId>StandardWebhooks</PackageId>
+    <PackageId>StandardWebhooks.StandardWebhooks</PackageId>
     <Version>1.0.1</Version>
     <Authors>Standard Webhooks</Authors>
     <Company>Standard Webhooks</Company>


### PR DESCRIPTION
Essentially did what was needed to make a release.