### PR TITLE
Proposal: Delivery control (`webhook-delivery` header)

### DIFF
--- a/spec/standard-webhooks.md
+++ b/spec/standard-webhooks.md
@@ -283,7 +283,11 @@ It's important to follow HTTP etiquette when sending webhooks, and respond to HT
 - `502 Bad Gateway` and `504 Gateway Timeout`: Both errors usually indicate that the server is under load, and it's recommended to throttle the requests.
 - The rest of the status codes should be treated as a failure.
 
-Additionally, some responses may also include a `retry-after` header (e.g. `503 Service Unavailable`), which should be taken into consideration when scheduling the next attempt.
+Some responses may also include a `retry-after` header (e.g. `503 Service Unavailable`), which should be taken into consideration when scheduling the next attempt.
+Additionally, the webhook-specific header `webhook-delivery` should be inspected for one of the following values:
+
+- `disable`: The receiving server is no longer interested in receiving webhooks from this source. Sender should disable the webhook endpoint, and stop sending it messages. (equivalent to the suggested `410 Gone` status code handling)
+- `abort-message`: The message being handled will never succeed, retries for this specific message should be stopped (but other messages should still be sent).
 
 #### Request timeouts
 


### PR DESCRIPTION
As implemented in Svix (my employer) recently. Svix documentation lives [here](https://docs.svix.com/receiving/delivery-control).

Motivation:
- The HTTP 410 handling suggested by the spec generally makes sense, but is not currently implemented by Svix and it is somewhat risky to add it now (could break things for existing customers); `webhook-delivery: disable` is more explicit so much safer to introduce
- `webhook-delivery: abort-message` is a new feature that can stop unnecessary webhook traffic in cases where the receiver knows that retries would fail anyways