### PR TITLE
python: Support skipping JSON parsing in verify

### DIFF
--- a/libraries/python/standardwebhooks/webhooks.py
+++ b/libraries/python/standardwebhooks/webhooks.py
@@ -38,7 +38,13 @@ class Webhook:
         else:
             raise RuntimeError("Invalid webhook secret")
 
-    def verify(self, data: t.Union[bytes, str], headers: t.Dict[str, str]) -> t.Any:
+    def verify(
+        self,
+        data: t.Union[bytes, str],
+        headers: t.Dict[str, str],
+        *,
+        json_parse: bool = True,
+    ) -> t.Any:
         data = data if isinstance(data, str) else data.decode()
         headers = {k.lower(): v for (k, v) in headers.items()}
         msg_id = headers.get("webhook-id")
@@ -57,7 +63,10 @@ class Webhook:
                 continue
             sig_bytes = base64.b64decode(signature)
             if hmac.compare_digest(expected_sig, sig_bytes):
-                return json.loads(data)
+                if json_parse:
+                    return json.loads(data)
+                else:
+                    return
 
         raise WebhookVerificationError("No matching signature found")
 

--- a/libraries/python/standardwebhooks/webhooks.py
+++ b/libraries/python/standardwebhooks/webhooks.py
@@ -45,6 +45,21 @@ class Webhook:
         *,
         json_parse: bool = True,
     ) -> t.Any:
+        """
+        Verify the given webhook headers against the body bytes (data).
+
+        Args:
+            json_parse (bool): Whether to deserialize the data to (default: True)
+
+        Returns:
+            After successful verification: if json_parse is True, returns the
+            JSON-parsed input data; if it json_parse False, returns None.
+
+        Raises:
+            WebhookVerificationError if one of the required headers is missing,
+            invalid, too old or too new; or no matching signature is found.
+        """
+
         data = data if isinstance(data, str) else data.decode()
         headers = {k.lower(): v for (k, v) in headers.items()}
         msg_id = headers.get("webhook-id")

--- a/libraries/python/tests/test_webhooks.py
+++ b/libraries/python/tests/test_webhooks.py
@@ -107,6 +107,15 @@ def test_valid_signature_is_valid_and_returns_json() -> None:
     assert json["test"] == 2432232314
 
 
+def test_valid_signature_is_valid_without_returning_json() -> None:
+    test_payload = PayloadForTesting()
+
+    wh = Webhook(test_payload.secret)
+
+    result = wh.verify(test_payload.payload, test_payload.header, json_parse=False)
+    assert result is None
+
+
 def test_valid_unbranded_signature_is_valid_and_returns_json() -> None:
     test_payload = PayloadForTesting()
 


### PR DESCRIPTION
Only some of the libraries automatically parse JSON, and it's obviously not always the right choice (the body doesn't even have to be JSON).