### PR TITLE
check in a license file for the python library

### DIFF
--- a/libraries/python/LICENSE
+++ b/libraries/python/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2023 Standard Webhooks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -31,6 +31,7 @@ classifiers=[
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
+license-files = ["LICENSE"]
 dependencies = []
 
 [dependency-groups]


### PR DESCRIPTION
The Python library is licensed under the MIT license, but a copy of it isn't in this repo (there's an Apache 2.0 license file in another directory, though).

Check in the license and make sure that it's included in source distributions.

Fixes #270.