### PR TITLE
Add JPMS module descriptor to the Java library

### DIFF
--- a/libraries/java/pom.xml
+++ b/libraries/java/pom.xml
@@ -87,7 +87,27 @@
                             <target>1.8</target>
                         </configuration>
                     </execution>
-                    <!-- Compile Java 11 override to MRJAR location -->
+                    <!-- Compile the module descriptor to META-INF/versions/9 so the JAR is an
+                         explicit JPMS module on Java 9+ while the root classes stay Java 8.
+                         multiReleaseOutput patches the Java 8 classes into the module being compiled. -->
+                    <execution>
+                        <id>java9-compile</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <jdkToolchain>
+                                <version>11</version>
+                            </jdkToolchain>
+                        </configuration>
+                    </execution>
+                    <!-- Compile Java 11 override (and its module descriptor) to MRJAR location -->
                     <execution>
                         <id>java11-compile</id>
                         <phase>prepare-package</phase>
@@ -99,7 +119,7 @@
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
                             </compileSourceRoots>
-                            <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11</outputDirectory>
+                            <multiReleaseOutput>true</multiReleaseOutput>
                             <jdkToolchain>
                                 <version>11</version>
                             </jdkToolchain>

--- a/libraries/java/src/main/java11/module-info.java
+++ b/libraries/java/src/main/java11/module-info.java
@@ -1,0 +1,12 @@
+/**
+ * Module descriptor seen by Java 11+ runtimes (META-INF/versions/11).
+ * Keep in sync with src/main/java9/module-info.java: a versioned descriptor may
+ * only add non-transitive requires of java.* modules, and java.net.http (used by
+ * the HttpHeaders overload of verify) does not exist before Java 11.
+ */
+module com.standardwebhooks {
+	requires java.net.http;
+
+	exports com.standardwebhooks;
+	exports com.standardwebhooks.exceptions;
+}

--- a/libraries/java/src/main/java9/module-info.java
+++ b/libraries/java/src/main/java9/module-info.java
@@ -1,0 +1,9 @@
+/**
+ * Module descriptor seen by Java 9 and 10 runtimes (META-INF/versions/9).
+ * Java 11+ runtimes see src/main/java11/module-info.java instead, which
+ * additionally reads java.net.http for the HttpHeaders overload of verify.
+ */
+module com.standardwebhooks {
+	exports com.standardwebhooks;
+	exports com.standardwebhooks.exceptions;
+}


### PR DESCRIPTION
The jar currently has no module-info and no Automatic-Module-Name, so on the module path it is only a filename-derived automatic module ("standardwebhooks"). Gradle's inferred module path ignores such jars entirely, so JPMS consumers of libraries that depend on standardwebhooks fail with "module not found: standardwebhooks".

Make the jar an explicit module named com.standardwebhooks. The descriptor is compiled with --release 9 into META-INF/versions/9 of the existing multi-release jar, so the root stays Java 8 bytecode and Java 8 consumers are unaffected. The Java 11 layer gets its own descriptor that additionally requires java.net.http for the HttpHeaders overload of Webhook.verify (java.net.http does not exist on Java 9/10); this is the only difference JEP 238 permits between versioned descriptors.