### PR TITLE
Java: update maven publish plugin.

### DIFF
--- a/libraries/java/pom.xml
+++ b/libraries/java/pom.xml
@@ -294,7 +294,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.6.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
The old version is no longer compatible with mave central.