### PR TITLE
javascript: Make JSON parsing optional in Webhook.verify

### DIFF
--- a/libraries/javascript/src/index.ts
+++ b/libraries/javascript/src/index.ts
@@ -31,6 +31,11 @@ export interface WebhookOptions {
   format?: "raw";
 }
 
+export interface VerifyOptions {
+  /** Whether to parse the payload as JSON on success (default: true) */
+  jsonParse?: boolean;
+}
+
 export class Webhook {
   private static prefix = "whsec_";
   private readonly key: Uint8Array;
@@ -58,14 +63,18 @@ export class Webhook {
 
   /** Verify the given webhook headers against the body bytes (payload).
    *
-   * @returns After successful verification: returns the JSON-parsed input data
+   * @returns After successful verification: if `options.jsonParse` is `true`, returns the
+   *     JSON-parsed input data; if `options.jsonParse` is `false`, returns `undefined`
    * @throws `WebhookVerificationError` if one of the required headers is missing,
    *     invalid, too old or too new; or no matching signatures is found
    */
   public verify(
     payload: string | Buffer,
-    headers: WebhookUnbrandedRequiredHeaders | Record<string, string>
+    headers: WebhookUnbrandedRequiredHeaders | Record<string, string>,
+    options?: VerifyOptions,
   ): unknown {
+    const jsonParse = options?.jsonParse ?? true;
+
     const normalizedHeaders: Record<string, string> = {};
     for (const key of Object.keys(headers)) {
       normalizedHeaders[key.toLowerCase()] = (headers as Record<string, string>)[key];
@@ -98,7 +107,11 @@ export class Webhook {
         if (payloadString === "") {
           return undefined;
         }
-        return JSON.parse(payloadString);
+        if (jsonParse) {
+          return JSON.parse(payloadString);
+        } else {
+          return undefined;
+        }
       }
     }
     throw new WebhookVerificationError("No matching signature found");

--- a/libraries/javascript/src/index.ts
+++ b/libraries/javascript/src/index.ts
@@ -56,18 +56,24 @@ export class Webhook {
     }
   }
 
+  /** Verify the given webhook headers against the body bytes (payload).
+   *
+   * @returns After successful verification: returns the JSON-parsed input data
+   * @throws `WebhookVerificationError` if one of the required headers is missing,
+   *     invalid, too old or too new; or no matching signatures is found
+   */
   public verify(
     payload: string | Buffer,
-    headers_: WebhookUnbrandedRequiredHeaders | Record<string, string>
+    headers: WebhookUnbrandedRequiredHeaders | Record<string, string>
   ): unknown {
-    const headers: Record<string, string> = {};
-    for (const key of Object.keys(headers_)) {
-      headers[key.toLowerCase()] = (headers_ as Record<string, string>)[key];
+    const normalizedHeaders: Record<string, string> = {};
+    for (const key of Object.keys(headers)) {
+      normalizedHeaders[key.toLowerCase()] = (headers as Record<string, string>)[key];
     }
 
-    const msgId = headers["webhook-id"];
-    const msgSignature = headers["webhook-signature"];
-    const msgTimestamp = headers["webhook-timestamp"];
+    const msgId = normalizedHeaders["webhook-id"];
+    const msgSignature = normalizedHeaders["webhook-signature"];
+    const msgTimestamp = normalizedHeaders["webhook-timestamp"];
 
     if (!msgSignature || !msgId || !msgTimestamp) {
       throw new WebhookVerificationError("Missing required headers");

--- a/libraries/javascript/src/webhook.test.ts
+++ b/libraries/javascript/src/webhook.test.ts
@@ -130,10 +130,18 @@ test("partial signature throws error", () => {
 
 test("valid signature is valid and returns valid json", () => {
   const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
-
   const testPayload = new TestPayload();
 
-  wh.verify(testPayload.payload, testPayload.header);
+  const result = wh.verify(testPayload.payload, testPayload.header);
+  assert.deepStrictEqual(result, { "test": 2432232314 });
+});
+
+test("valid signature is valid without returning json", () => {
+  const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
+  const testPayload = new TestPayload();
+
+  const result = wh.verify(testPayload.payload, testPayload.header, { jsonParse: false });
+  assert.strictEqual(result, undefined);
 });
 
 test("valid unbranded signature is valid and returns valid json", () => {

--- a/libraries/python/standardwebhooks/webhooks.py
+++ b/libraries/python/standardwebhooks/webhooks.py
@@ -49,7 +49,7 @@ class Webhook:
         Verify the given webhook headers against the body bytes (data).
 
         Args:
-            json_parse (bool): Whether to deserialize the data to (default: True)
+            json_parse (bool): Whether to parse the data as JSON on success (default: True)
 
         Returns:
             After successful verification: if json_parse is True, returns the


### PR DESCRIPTION
… and some drive-by docs improvements.

Same thing I did for Python in #292.