### PR TITLE
Normalize headers to support case-insensitivity (PHP, Ruby)

### DIFF
--- a/libraries/php/src/Webhook.php
+++ b/libraries/php/src/Webhook.php
@@ -28,6 +28,9 @@ class Webhook
 
     public function verify($payload, $headers)
     {
+        // normalize headers as they are case-insensitive
+        $headers = array_change_key_case($headers, CASE_LOWER);
+
         if (
             isset($headers['webhook-id'])
             && isset($headers['webhook-timestamp'])

--- a/libraries/php/tests/WebhookTest.php
+++ b/libraries/php/tests/WebhookTest.php
@@ -201,6 +201,36 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $signature = $wh->sign($msgId, $timestamp, $payload);
     }
 
+    public function testVerifyWithUpperCaseHeaders()
+    {
+        $testPayload = new TestPayload(time());
+        $upperHeaders = [
+            'WEBHOOK-ID'        => $testPayload->header['webhook-id'],
+            'WEBHOOK-TIMESTAMP' => $testPayload->header['webhook-timestamp'],
+            'WEBHOOK-SIGNATURE' => $testPayload->header['webhook-signature'],
+        ];
+
+        $wh = new \StandardWebhooks\Webhook($testPayload->secret);
+        $json = $wh->verify($testPayload->payload, $upperHeaders);
+
+        $this->assertEquals(2432232315, $json['test']);
+    }
+
+    public function testVerifyWithMixedCaseHeaders()
+    {
+        $testPayload = new TestPayload(time());
+        $mixedHeaders = [
+            'Webhook-Id'        => $testPayload->header['webhook-id'],
+            'Webhook-Timestamp' => $testPayload->header['webhook-timestamp'],
+            'Webhook-Signature' => $testPayload->header['webhook-signature'],
+        ];
+
+        $wh = new \StandardWebhooks\Webhook($testPayload->secret);
+        $json = $wh->verify($testPayload->payload, $mixedHeaders);
+
+        $this->assertEquals(2432232315, $json['test']);
+    }
+
     public function testRejectsEmptySecret()
     {
         $this->expectException(\StandardWebhooks\Exception\EmptyWebhookSecretException::class);

--- a/libraries/ruby/lib/standardwebhooks/webhooks.rb
+++ b/libraries/ruby/lib/standardwebhooks/webhooks.rb
@@ -24,6 +24,9 @@ module StandardWebhooks
     end
 
     def verify(payload, headers)
+      # normalize headers as they are case-insensitive
+      headers = headers.transform_keys(&:downcase)
+
       msg_id = headers["webhook-id"]
       msg_signature = headers["webhook-signature"]
       msg_timestamp = headers["webhook-timestamp"]

--- a/libraries/ruby/spec/webhook_spec.rb
+++ b/libraries/ruby/spec/webhook_spec.rb
@@ -176,6 +176,32 @@ describe StandardWebhooks::Webhook do
     expect(json["test"]).to eq(2432232314)
   end
 
+  it "valid uppercase headers are accepted" do
+    testPayload = TestPayload.new
+    upperHeaders = {
+      "WEBHOOK-ID" => testPayload.headers["webhook-id"],
+      "WEBHOOK-TIMESTAMP" => testPayload.headers["webhook-timestamp"],
+      "WEBHOOK-SIGNATURE" => testPayload.headers["webhook-signature"]
+    }
+
+    wh = StandardWebhooks::Webhook.new(testPayload.secret)
+    json = wh.verify(testPayload.payload, upperHeaders)
+    expect(json["test"]).to eq(2432232314)
+  end
+
+  it "valid mixed-case headers are accepted" do
+    testPayload = TestPayload.new
+    mixedHeaders = {
+      "Webhook-Id" => testPayload.headers["webhook-id"],
+      "Webhook-Timestamp" => testPayload.headers["webhook-timestamp"],
+      "Webhook-Signature" => testPayload.headers["webhook-signature"]
+    }
+
+    wh = StandardWebhooks::Webhook.new(testPayload.secret)
+    json = wh.verify(testPayload.payload, mixedHeaders)
+    expect(json["test"]).to eq(2432232314)
+  end
+
   it "sign function works" do
     key = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
     msg_id = "msg_p5jXN8AQM9LWM0D4loKWxJek"


### PR DESCRIPTION
Handle headers in case-insensitive way, as RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers" states:

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

Normalization was missing in PHP and Ruby implementation

@tasn Would you like to review? Kind regards